### PR TITLE
Ad Astra "Preparing Some Oxygen" quest step fix

### DIFF
--- a/config/ftbquests/quests/chapters/ad_astra.snbt
+++ b/config/ftbquests/quests/chapters/ad_astra.snbt
@@ -766,7 +766,7 @@
 					id: "0DE204C9101E0A72"
 					item: {
 						Count: 1b
-						id: "ad_astra:oxygen_tank"
+						id: "ad_astra:gas_tank"
 						tag: {
 							BotariumData: { }
 						}


### PR DESCRIPTION
Applies fix to Ad Astra "Preparing Some Oxygen" quest step from the main ATM 9 pack

https://github.com/AllTheMods/ATM-9/pull/1381