### PR TITLE
Merge Fixes from ATM9

### DIFF
--- a/config/inventoryprofilesnext/integrationHints/refinedstorage.json
+++ b/config/inventoryprofilesnext/integrationHints/refinedstorage.json
@@ -161,6 +161,10 @@
             }
         }
     },
+    "com.refinedmods.refinedstorage.screen.CrafterManagerScreen": {
+        "playerSideOnly": true,
+        "ignore": true
+    },
     "com.refinedmods.refinedstorage.screen.PriorityScreen": {
         "ignore": true
     },

--- a/config/quark-common.toml
+++ b/config/quark-common.toml
@@ -14,7 +14,8 @@
 [tweaks]
 	"Automatic Recipe Unlock" = false
 	"Simple Harvest" = false
-		[tweaks.utility_recipes]
+
+	[tweaks.utility_recipes]
 		"Easy Sticks" = false
 
 [world]
@@ -22,11 +23,6 @@
 
 [client]
 	"Back Button Keybind" = false
-
-[tools]
-	Abacus = true
-	"Ambient Discs" = true
-	"Ancient Tomes" = false
 
 [building]
 	"Celebratory Lamps" = true

--- a/kubejs/data/powah/recipes/energizing/dry_ice/2x_dry_ice.json
+++ b/kubejs/data/powah/recipes/energizing/dry_ice/2x_dry_ice.json
@@ -1,0 +1,14 @@
+{
+  "type": "powah:energizing",
+  "ingredients": [
+	{"item": "minecraft:blue_ice"},
+  {"item": "minecraft:blue_ice"},
+  {"item": "minecraft:blue_ice"},
+	{"item": "minecraft:blue_ice"}
+  ],
+  "energy": 20000,
+  "result": {
+	"item": "powah:dry_ice",
+  "count": 2
+  }
+}

--- a/kubejs/data/powah/recipes/energizing/dry_ice/3x_dry_ice.json
+++ b/kubejs/data/powah/recipes/energizing/dry_ice/3x_dry_ice.json
@@ -1,0 +1,16 @@
+{
+  "type": "powah:energizing",
+  "ingredients": [
+	{"item": "minecraft:blue_ice"},
+  {"item": "minecraft:blue_ice"},
+	{"item": "minecraft:blue_ice"},
+	{"item": "minecraft:blue_ice"},
+	{"item": "minecraft:blue_ice"},
+	{"item": "minecraft:blue_ice"}
+  ],
+  "energy": 30000,
+  "result": {
+	"item": "powah:dry_ice",
+  "count": 3
+  }
+}

--- a/kubejs/data/productivebees/recipes/bee_conversion/wasted_radioactive_bee.json
+++ b/kubejs/data/productivebees/recipes/bee_conversion/wasted_radioactive_bee.json
@@ -1,0 +1,19 @@
+{
+    "type": "productivebees:bee_conversion",
+    "source": "productivebees:radioactive",
+    "result": "productivebees:wasted_radioactive",
+    "item": {
+        "item": "mekanism:pellet_polonium"
+    },
+    "chance": 5,
+    "conditions": [
+        {
+            "type": "productivebees:bee_exists",
+            "bee": "productivebees:radioactive"
+        },
+        {
+            "type": "productivebees:bee_exists",
+            "bee": "productivebees:wasted_radioactive"
+        }
+    ]
+}

--- a/kubejs/server_scripts/modpack/atm_shard.js
+++ b/kubejs/server_scripts/modpack/atm_shard.js
@@ -4,11 +4,11 @@ ServerEvents.recipes(e => {
 //#SilentGear
   e.shapeless('32x allthetweaks:allthecatalystium', shard)
 //#Pipez
-  e.shaped('16x pipez:infinity_upgrade', ['ABA', 'BCB', 'ADA'], {
-    A: 'allthemodium:unobtainium_ingot',
-    B: 'minecraft:redstone_block',
-    C: 'pipez:ultimate_upgrade',
-    D: shard
-  })
+//  e.shaped('16x pipez:infinity_upgrade', ['ABA', 'BCB', 'ADA'], {
+//   A: 'allthemodium:unobtainium_ingot',
+//    B: 'minecraft:redstone_block',
+//    C: 'pipez:ultimate_upgrade',
+//    D: shard
+//  })
 
 })

--- a/kubejs/server_scripts/modpack/atm_star_creative.js
+++ b/kubejs/server_scripts/modpack/atm_star_creative.js
@@ -19,11 +19,11 @@ ServerEvents.recipes(e => {
   e.custom({
     type: 'powah:energizing',
     ingredients: [
-      Ingredient.of('ae2:dense_energy_cell').toJson(),
-      Ingredient.of('ae2:dense_energy_cell').toJson(),
+      Ingredient.of('megacells:mega_energy_cell').toJson(),
+      Ingredient.of('megacells:mega_energy_cell').toJson(),
       Ingredient.of('allthetweaks:atm_star').toJson(),
-      Ingredient.of('ae2:dense_energy_cell').toJson(),
-      Ingredient.of('ae2:dense_energy_cell').toJson(),
+      Ingredient.of('megacells:mega_energy_cell').toJson(),
+      Ingredient.of('megacells:mega_energy_cell').toJson(),
     ],
     energy: '2147483647',
     result: Item.of('ae2:creative_energy_cell').toJson()

--- a/kubejs/server_scripts/modpack/att_items.js
+++ b/kubejs/server_scripts/modpack/att_items.js
@@ -53,7 +53,7 @@ ServerEvents.recipes(event => {
     B: 'computercraft:pocket_computer_advanced',
     C: ['extradisks:1048576k_storage_part', 'extradisks:1048576k_fluid_storage_part', 'megacells:cell_component_256m'],
     E: 'rftoolsutility:flight_module',
-    F: Item.of('powah:battery_nitro', '{powah_tile_data:{energy_stored_main_energy:2000000000L}}').strongNBT(),
+    F: Item.of('powah:battery_nitro', '{powah_tile_data:{energy_stored_main_energy:2000000000L}}').weakNBT(),
     G: 'ad_astra:jet_suit'
     }).id('kubejs:allthetweaks/improbable_probability_device')
   
@@ -93,8 +93,8 @@ ServerEvents.recipes(event => {
   // Oblivion Shard
   event.shaped('allthetweaks:oblivion_shard', [' AB', 'ACA', 'BA '], {
     A: 'forbidden_arcanus:eternal_stella',
-    C: 'naturesaura:end_flower',
-    B: 'naturesaura:chunk_loader'
+    C: Item.of('evilcraft:mace_of_destruction', '{Fluid: {FluidName: "evilcraft:blood", Amount: 4000}}').weakNBT(),
+    B: 'evilcraft:piercing_vengeance_focus'
   }).id('kubejs:allthetweaks/oblivion_shard')
 
   // Creative Essence

--- a/kubejs/server_scripts/mods/corail_tombstone/Nuke_Eggs.js
+++ b/kubejs/server_scripts/mods/corail_tombstone/Nuke_Eggs.js
@@ -1,0 +1,5 @@
+EntityEvents.spawned("item", e => {
+    if (e.entity.item.id == "tombstone:easter_egg") {
+      if (!e.entity.nbt.Thrower) e.cancel()
+    }
+  })

--- a/kubejs/server_scripts/mods/mysticalagriculture/crafting.js
+++ b/kubejs/server_scripts/mods/mysticalagriculture/crafting.js
@@ -86,7 +86,7 @@ ServerEvents.recipes(event => {
   let soil2 = 'mysticalagradditions:insanium_block'
   seedCrafting('kubejs:magical_soil', soilMid, soil1, soil2, soil1, soil2, soil1, soil2, soil1, soil2)
 
-/*
+
   //MA EXP droplets to fluid EXP
   event.custom({
     type: "thermal:centrifuge",
@@ -101,7 +101,7 @@ ServerEvents.recipes(event => {
     ],
     energy: 400
   })
-*/
+
   // remove gaia crux
   event.remove({ id: "mysticalagradditions:gaia_spirit_crux" })
 })

--- a/kubejs/server_scripts/mods/refined/recipes.js
+++ b/kubejs/server_scripts/mods/refined/recipes.js
@@ -1,0 +1,18 @@
+ServerEvents.recipes( event => {
+    event.remove('extradisks:disk/shaped/infinite_storage_disk')
+    event.remove('extradisks:blocks/infinite_storage_block')
+    event.remove('extradisks:part/infinite_storage_part')
+    event.remove('extradisks:disk/shaped/infinite_fluid_storage_disk')
+    event.remove('extradisks:part/infinite_fluid_storage_part')
+    event.remove('extradisks:blocks/infinite_fluid_storage_block')
+})
+
+ServerEvents.recipes(event => {
+    event.remove({ id: 'rsinfinitybooster:infinity_card' })
+    event.shaped('rsinfinitybooster:infinity_card', ['EBE', 'BUB', 'NNN'], {
+      U: '#forge:ingots/unobtainium',
+      B: 'refinedstorage:range_upgrade',
+      E: '#forge:plates/enderium',
+      N: 'minecraft:netherite_ingot'
+    }).id('kubejs:rsinfinitybooster/infinity_card')
+  })


### PR DESCRIPTION
Prevent sorting in the refined storage crafting manager. 
Re-enable quark ancient tomes.
Add bulk crafting for dry ice.
Disable the ability to craft the pipez infinity upgrade. 
Change the AE creative energy cell to use super dense cells to craft. 
Enable improbable probability device to be more flexible with Powah Batteries. 
Change RS infinite card to match AE
Remove Corail Eggs by Uncandango
Swap Nature's Aura to Evilcraft
Disable 262m/infinite disks